### PR TITLE
Updates alternative installation in index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -21,26 +21,21 @@ can be installed easily:
 
 Alternatively one can download and install it from the repositories as well:
 
-    ```bash
     git clone https://github.com/Copilot-Language/Copilot.git
     cd Copilot
     git submodule update --init --remote
-    ```
 
   Compiling can either be done in a Nix-style build, or a traditional one:
 
   _Nix-Style build (Cabal >= 2.x)_
 
-    ```bash
     cabal build       # For Cabal 3.x
     cabal v2-build    # For Cabal 2.x
-    ```
 
   _Traditional build (Cabal 1.x)_
-    ```bash
+
     cabal install --dependencies-only
     cabal build
-    ```
 
 Typically one would only go this route to develop Copilot. For regular users
 the cabal method is highly recommended.

--- a/index.md
+++ b/index.md
@@ -27,16 +27,16 @@ Alternatively one can download and install it from the repositories as well:
     git submodule update --init --remote
     ```
 
-    Compiling can either be done in a Nix-style build, or a traditional one:
+  Compiling can either be done in a Nix-style build, or a traditional one:
 
-    _Nix-Style build (Cabal >= 2.x)_
+  _Nix-Style build (Cabal >= 2.x)_
 
     ```bash
     cabal build       # For Cabal 3.x
     cabal v2-build    # For Cabal 2.x
     ```
 
-    _Traditional build (Cabal 1.x)_
+  _Traditional build (Cabal 1.x)_
     ```bash
     cabal install --dependencies-only
     cabal build

--- a/index.md
+++ b/index.md
@@ -21,10 +21,26 @@ can be installed easily:
 
 Alternatively one can download and install it from the repositories as well:
 
-    git clone --recursive https://github.com/Copilot-Language/Copilot.git
+    ```bash
+    git clone https://github.com/Copilot-Language/Copilot.git
     cd Copilot
     git submodule update --init --remote
-    make
+    ```
+
+    Compiling can either be done in a Nix-style build, or a traditional one:
+
+    _Nix-Style build (Cabal >= 2.x)_
+
+    ```bash
+    cabal build       # For Cabal 3.x
+    cabal v2-build    # For Cabal 2.x
+    ```
+
+    _Traditional build (Cabal 1.x)_
+    ```bash
+    cabal install --dependencies-only
+    cabal build
+    ```
 
 Typically one would only go this route to develop Copilot. For regular users
 the cabal method is highly recommended.


### PR DESCRIPTION
It copies the 'Alternative installation' from the [Copilot Readme](https://github.com/Copilot-Language/Copilot/blob/master/README.md).
    
The Readme of the Copilot-Language repo was currently updated and includes a fixed and more precise description for the alternative installation. This PR includes the copying of this part into the index.md and adjusts some styling issues in the copied part.
    
Refs #9.