### PR TITLE
documentation: fix examples link

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -2,8 +2,8 @@
 A manual to Copilot can be downloaded [here](downloads/copilot_tutorial.pdf).
 
 Copilot comes with a set of examples as part of its distribution, available in
-the [Examples
-directory](https://github.com/Copilot-Language/Copilot/tree/master/Examples) of
+the [examples
+directory](https://github.com/Copilot-Language/Copilot/tree/master/examples) of
 the repository.
 
 


### PR DESCRIPTION
This fixes the broken 
[Examples link](https://github.com/Copilot-Language/Copilot/tree/master/Examples)
on https://copilot-language.github.io/documentation.html